### PR TITLE
feat: Integrate backend components and templates with tldraw

### DIFF
--- a/jules-scratch/verification/verify_changes.py
+++ b/jules-scratch/verification/verify_changes.py
@@ -1,0 +1,31 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        page.goto("http://localhost:5173/")
+        page.wait_for_load_state('networkidle')
+
+        # 1. Verify the left sidebar is gone.
+        expect(page.locator('[data-testid="designer-page"]')).to_be_visible()
+        page.screenshot(path="jules-scratch/verification/01_no_sidebar.png")
+
+        # 2. Add a component.
+        page.get_by_role("button", name="Add Component").click()
+        page.get_by_role("menuitem", name="AWS Lambda").click()
+        expect(page.get_by_text("AWS Lambda")).to_be_visible()
+        page.screenshot(path="jules-scratch/verification/02_component_added.png")
+
+        # 3. Apply a template.
+        page.get_by_role("button", name="Templates").click()
+        # Click the first template in the dropdown.
+        page.get_by_role("menuitem").first.click()
+        page.wait_for_timeout(1000) # wait for render
+        page.screenshot(path="jules-scratch/verification/03_template_applied.png")
+
+        browser.close()
+
+if __name__ == "__main__":
+    run()

--- a/src/components/ComponentPicker.tsx
+++ b/src/components/ComponentPicker.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useCanvasStore } from '@/store/canvasStore';
+import type { EnrichedComponent } from '@/store/canvasStore';
+
+export function ComponentPicker() {
+  const { componentLibrary, addComponent } = useCanvasStore();
+
+  const groupedComponents = useMemo(() => {
+    return componentLibrary.reduce((acc, component) => {
+      if (!acc[component.category]) {
+        acc[component.category] = [];
+      }
+      acc[component.category].push(component);
+      return acc;
+    }, {} as Record<string, EnrichedComponent[]>);
+  }, [componentLibrary]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">Add Component</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuLabel>Component Library</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {Object.entries(groupedComponents).map(([category, components]) => (
+          <DropdownMenuGroup key={category}>
+            <DropdownMenuLabel>{category}</DropdownMenuLabel>
+            {components.map((component) => (
+              <DropdownMenuItem
+                key={component.id}
+                onSelect={() => addComponent(component.id)}
+              >
+                {component.name}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/TemplatePicker.tsx
+++ b/src/components/TemplatePicker.tsx
@@ -1,42 +1,38 @@
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { Button } from "@/components/ui/button"
-import { LayoutTemplate } from "lucide-react"
-import { MOCK_TEMPLATES } from "@/utils/mock-templates"
+} from '@/components/ui/dropdown-menu';
+import { getAllTemplates } from '@/services/api';
+import type { Template } from '@/types/api';
+import { useCanvasStore } from '@/store/canvasStore';
 
 export function TemplatePicker() {
-  const handleLoadTemplate = (design: any) => {
-    // TODO: Re-implement template loading with Excalidraw
-    console.log("Template loading is not implemented yet.", design);
-  };
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const applyTemplate = useCanvasStore((state) => state.applyTemplate);
+
+  useEffect(() => {
+    getAllTemplates().then(setTemplates).catch(console.error);
+  }, []);
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm">
-          <LayoutTemplate className="h-4 w-4 mr-2" />
-          Templates
-        </Button>
+        <Button variant="outline">Templates</Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuLabel>Load a Template</DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        {MOCK_TEMPLATES.map((template) => (
+        {templates.map((template) => (
           <DropdownMenuItem
-            key={template.name}
-            onClick={() => handleLoadTemplate(template.design)}
-            disabled // Temporarily disable until re-implemented
+            key={template.id}
+            onSelect={() => applyTemplate(template)}
           >
             {template.name}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
-  )
+  );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -13,6 +13,7 @@ import {
 import { LogOut, Save, PlusCircle, ChevronsUpDown, Undo2, Redo2 } from 'lucide-react';
 import { ThemeToggle } from './ThemeToggle';
 import { TemplatePicker } from './TemplatePicker';
+import { ComponentPicker } from './ComponentPicker';
 import * as api from '@/services/api';
 import type { Design } from '@/types/api';
 import { useAuth } from '@/contexts/AuthContext';
@@ -146,6 +147,7 @@ export function TopBar() {
         <Button variant="outline" size="icon" onClick={handleSave} disabled={isSaving} title="Save">
           <Save className="h-4 w-4" />
         </Button>
+        <ComponentPicker />
         <TemplatePicker />
         <ThemeToggle />
         <Button variant="outline" size="icon" onClick={handleLogout} title="Logout">

--- a/src/pages/DesignerPage.tsx
+++ b/src/pages/DesignerPage.tsx
@@ -3,7 +3,6 @@ import { Tldraw, useEditor, createShapeId, getSnapshot, createTLStore, loadSnaps
 import type { TLEditorComponents } from 'tldraw';
 import 'tldraw/tldraw.css';
 import { useCanvasStore } from '../store/canvasStore';
-import { ComponentPalette } from '@/components/ComponentPalette';
 import { RightSidebar } from '@/components/RightSidebar';
 import { useAutoSave } from '@/hooks/useAutoSave';
 
@@ -115,7 +114,6 @@ function DesignerPage() {
 
   return (
     <div className="flex h-full w-full" data-testid="designer-page">
-      <ComponentPalette />
       <div className="flex-grow h-full" style={{ position: 'relative' }}>
         <Tldraw store={store} components={components}>
             <StateManager />


### PR DESCRIPTION
This commit integrates the backend components and templates with the tldraw canvas, and removes the left sidebar for components.

Changes include:
- Removed the `ComponentPalette` (left sidebar) from the `DesignerPage`.
- Created a `TemplatePicker` component in the `TopBar` to select and apply design templates fetched from the backend.
- Created a `ComponentPicker` component in the `TopBar` to add components to the canvas.
- Updated the `canvasStore` to manage templates and components:
  - Added state for templates.
  - Added `fetchTemplates` action to get templates from the API.
  - Added `applyTemplate` action to add template components to the canvas.
  - Added `addComponent` action to add a single component to the canvas.

Verification:
I attempted to verify the changes using a Playwright script, but I was unable to start the development server. Both `yarn dev` and `npm run dev` commands failed, preventing me from running the end-to-end verification. The code changes are complete, but they have not been visually verified.